### PR TITLE
fix: delete doc from old route when it changes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,9 +31,6 @@ RSpec/MessageSpies:
 RSpec/FilePath:
   Enabled: false
 
-RSpec/SpecFilePathFormat:
-  Enabled: false
-
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,3 +46,6 @@ Style/TrailingCommaInHashLiteral:
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: single_quotes
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    esse-active_record (0.2.0)
+    esse-active_record (0.2.1)
       activerecord (>= 4.2, < 8)
       esse (>= 0.2.3)
 

--- a/ci/Gemfile.rails-5.2.lock
+++ b/ci/Gemfile.rails-5.2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse-active_record (0.2.0)
+    esse-active_record (0.2.1)
       activerecord (>= 4.2, < 8)
       esse (>= 0.2.3)
 
@@ -157,4 +157,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.3.21
+   2.3.22

--- a/ci/Gemfile.rails-6.0.lock
+++ b/ci/Gemfile.rails-6.0.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse-active_record (0.2.0)
+    esse-active_record (0.2.1)
       activerecord (>= 4.2, < 8)
       esse (>= 0.2.3)
 

--- a/ci/Gemfile.rails-6.1.lock
+++ b/ci/Gemfile.rails-6.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse-active_record (0.2.0)
+    esse-active_record (0.2.1)
       activerecord (>= 4.2, < 8)
       esse (>= 0.2.3)
 

--- a/ci/Gemfile.rails-7.0.lock
+++ b/ci/Gemfile.rails-7.0.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse-active_record (0.2.0)
+    esse-active_record (0.2.1)
       activerecord (>= 4.2, < 8)
       esse (>= 0.2.3)
 

--- a/ci/Gemfile.rails-7.1.lock
+++ b/ci/Gemfile.rails-7.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse-active_record (0.2.0)
+    esse-active_record (0.2.1)
       activerecord (>= 4.2, < 8)
       esse (>= 0.2.3)
 

--- a/lib/esse/active_record/version.rb
+++ b/lib/esse/active_record/version.rb
@@ -2,6 +2,6 @@
 
 module Esse
   module ActiveRecord
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end

--- a/spec/esse/active_record/model_spec.rb
+++ b/spec/esse/active_record/model_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Esse::ActiveRecord::Model do
             _id: county.id,
             name: county.name,
             type: 'county',
+            routing: (county.state_id || 1),
           }.tap do |doc|
             doc[:state] = { id: county.state.id, name: county.state.name } if county.state
           end
@@ -170,6 +171,70 @@ RSpec.describe Esse::ActiveRecord::Model do
         ).and_return(index_ok_response)
 
         model.touch
+      end
+
+      context "when the document has a routing key" do
+        let(:model_class) do
+          Class.new(County) do
+            include Esse::ActiveRecord::Model
+            index_callbacks 'geographies:county', on: %i[update]
+          end
+        end
+        let(:il) { create_record(State, name: 'Illinois') }
+        let(:ny) { create_record(State, name: 'New York') }
+        let(:county) { create_record(model_class, name: 'Cook', state: il) }
+
+        it 'indexes the document in new routing and deletes the document from previous routing' do
+          expect(GeographiesIndex).to receive(:index).and_call_original
+          expect(GeographiesIndex).to esse_receive_request(:index).with(
+            id: county.id,
+            index: GeographiesIndex.index_name,
+            routing: ny.id,
+            body: {name: 'Cook', type: 'county', state: { id: ny.id, name: ny.name }},
+          ).and_return(index_ok_response)
+
+          expect(GeographiesIndex).to receive(:delete).and_call_original
+          expect(GeographiesIndex).to esse_receive_request(:delete).with(
+            id: county.id,
+            index: GeographiesIndex.index_name,
+            routing: il.id,
+          ).and_return('result' => 'deleted')
+
+          county.update(state: ny)
+        end
+
+        it 'does not delete the document when the routing key is not changed' do
+          expect(GeographiesIndex).to receive(:index).and_call_original
+          expect(GeographiesIndex).to esse_receive_request(:index).with(
+            id: county.id,
+            index: GeographiesIndex.index_name,
+            routing: il.id,
+            body: {name: 'Cook County', type: 'county', state: { id: il.id, name: il.name }},
+          ).and_return(index_ok_response)
+
+          expect(GeographiesIndex).not_to receive(:delete)
+
+          county.update(name: 'Cook County')
+        end
+
+        it 'does not raise error when the document does not exist' do
+          expect(GeographiesIndex).to receive(:index).and_call_original
+          expect(GeographiesIndex).to esse_receive_request(:index).with(
+            id: county.id,
+            index: GeographiesIndex.index_name,
+            routing: ny.id,
+            body: {name: 'Cook', type: 'county', state: { id: ny.id, name: ny.name }},
+          ).and_return(index_ok_response)
+
+          expect(GeographiesIndex).to receive(:delete).and_call_original
+          expect(GeographiesIndex).to esse_receive_request(:delete).with(
+            id: county.id,
+            index: GeographiesIndex.index_name,
+            routing: il.id,
+          ).and_raise_http_status(404, { 'error' => { 'type' => 'not_found' } })
+
+          county.update(state: ny)
+        end
       end
 
       it 'index the associated model using the block definition' do

--- a/spec/esse/active_record/model_spec.rb
+++ b/spec/esse/active_record/model_spec.rb
@@ -239,6 +239,7 @@ RSpec.describe Esse::ActiveRecord::Model do
     end
 
     context 'when on :update with a the document that has a routing key' do
+      let(:index_ok_response) { { 'result' => 'indexed' } }
       let(:model_class) do
         Class.new(County) do
           include Esse::ActiveRecord::Model

--- a/spec/esse/active_record/model_spec.rb
+++ b/spec/esse/active_record/model_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Esse::ActiveRecord::Model do
             _id: county.id,
             name: county.name,
             type: 'county',
-            routing: (county.state_id || 1),
+            routing: county.state_id || 1,
           }.tap do |doc|
             doc[:state] = { id: county.state.id, name: county.state.name } if county.state
           end

--- a/spec/esse/plugin/active_record/collection_definition_spec.rb
+++ b/spec/esse/plugin/active_record/collection_definition_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Esse::Plugins::ActiveRecord, '.collection' do
+RSpec.describe Esse::Plugins::ActiveRecord, '.collection' do # rubocop:disable RSpec/SpecFilePathFormat
   describe 'index collection definition' do
     context 'when the type is a model class' do
       it 'define collection with only class name without raise an error' do


### PR DESCRIPTION
When the routing is set to a specific document and it changes, we need to make sure to remove it from its previous route.