### PR TITLE
feat: after update smart detects to use :update when lazy are present

### DIFF
--- a/lib/esse/active_record/callbacks.rb
+++ b/lib/esse/active_record/callbacks.rb
@@ -5,8 +5,9 @@ module Esse
     class Callback
       attr_reader :repo, :options, :block_result
 
-      def initialize(repo:, block_result: nil, **kwargs)
+      def initialize(repo:, block_result: nil, with: nil, **kwargs)
         @repo = repo
+        @with = with
         @options = kwargs
         @block_result = block_result
       end

--- a/lib/esse/active_record/callbacks/indexing_on_update.rb
+++ b/lib/esse/active_record/callbacks/indexing_on_update.rb
@@ -3,13 +3,6 @@
 module Esse::ActiveRecord
   module Callbacks
     class IndexingOnUpdate < Callback
-      attr_reader :update_with
-
-      def initialize(with: :index, **kwargs, &block)
-        @update_with = with
-        super(**kwargs, &block)
-      end
-
       def call(model)
         record = block_result || model
 
@@ -43,7 +36,7 @@ module Esse::ActiveRecord
       def update_document(document)
         return if document.ignore_on_index?
 
-        if update_with == :update
+        if @with == :update || (@with.nil? && repo.lazy_document_attributes.any?)
           begin
             repo.index.update(document, **options)
           rescue Esse::Transport::NotFoundError

--- a/lib/esse/active_record/collection.rb
+++ b/lib/esse/active_record/collection.rb
@@ -90,7 +90,7 @@ module Esse
       end
 
       def count
-        dataset.except(:includes, :preload, :eager_load, :order, :limit, :offset).count
+        dataset.except(:includes, :preload, :eager_load, :group, :order, :limit, :offset).count
       end
       alias_method :size, :count
 


### PR DESCRIPTION
The document itself may not include the lazy attributes, and by
performing :index request all the updated done through the lazy update
attribute actions will be lost. So updated the logic to attempt push
document using :update api with a :index fallback in case doc does not
exist yet. This behaviour can be overriten by passing with: :index