### PR TITLE
Smart update with :update index with lazy attributes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    esse-active_record (0.3.5)
+    esse-active_record (0.3.6)
       activerecord (>= 4.2, < 8)
       esse (>= 0.3.0)
 

--- a/ci/Gemfile.rails-5.2.lock
+++ b/ci/Gemfile.rails-5.2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse-active_record (0.3.5)
+    esse-active_record (0.3.6)
       activerecord (>= 4.2, < 8)
       esse (>= 0.3.0)
 

--- a/ci/Gemfile.rails-6.0.lock
+++ b/ci/Gemfile.rails-6.0.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse-active_record (0.3.5)
+    esse-active_record (0.3.6)
       activerecord (>= 4.2, < 8)
       esse (>= 0.3.0)
 

--- a/ci/Gemfile.rails-6.1.lock
+++ b/ci/Gemfile.rails-6.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse-active_record (0.3.5)
+    esse-active_record (0.3.6)
       activerecord (>= 4.2, < 8)
       esse (>= 0.3.0)
 

--- a/ci/Gemfile.rails-7.0.lock
+++ b/ci/Gemfile.rails-7.0.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse-active_record (0.3.5)
+    esse-active_record (0.3.6)
       activerecord (>= 4.2, < 8)
       esse (>= 0.3.0)
 

--- a/ci/Gemfile.rails-7.1.lock
+++ b/ci/Gemfile.rails-7.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse-active_record (0.3.5)
+    esse-active_record (0.3.6)
       activerecord (>= 4.2, < 8)
       esse (>= 0.3.0)
 

--- a/lib/esse/active_record/callbacks.rb
+++ b/lib/esse/active_record/callbacks.rb
@@ -5,8 +5,9 @@ module Esse
     class Callback
       attr_reader :repo, :options, :block_result
 
-      def initialize(repo:, block_result: nil, **kwargs)
+      def initialize(repo:, block_result: nil, with: nil, **kwargs)
         @repo = repo
+        @with = with
         @options = kwargs
         @block_result = block_result
       end

--- a/lib/esse/active_record/callbacks/indexing_on_update.rb
+++ b/lib/esse/active_record/callbacks/indexing_on_update.rb
@@ -3,13 +3,6 @@
 module Esse::ActiveRecord
   module Callbacks
     class IndexingOnUpdate < Callback
-      attr_reader :update_with
-
-      def initialize(with: :index, **kwargs, &block)
-        @update_with = with
-        super(**kwargs, &block)
-      end
-
       def call(model)
         record = block_result || model
 
@@ -43,7 +36,7 @@ module Esse::ActiveRecord
       def update_document(document)
         return if document.ignore_on_index?
 
-        if update_with == :update
+        if @with == :update || (@with.nil? && repo.lazy_document_attributes.any?)
           begin
             repo.index.update(document, **options)
           rescue Esse::Transport::NotFoundError

--- a/lib/esse/active_record/collection.rb
+++ b/lib/esse/active_record/collection.rb
@@ -90,7 +90,7 @@ module Esse
       end
 
       def count
-        dataset.except(:includes, :preload, :eager_load, :order, :limit, :offset).count
+        dataset.except(:includes, :preload, :eager_load, :group, :order, :limit, :offset).count
       end
       alias_method :size, :count
 

--- a/lib/esse/active_record/version.rb
+++ b/lib/esse/active_record/version.rb
@@ -2,6 +2,6 @@
 
 module Esse
   module ActiveRecord
-    VERSION = '0.3.5'
+    VERSION = '0.3.6'
   end
 end


### PR DESCRIPTION
Indexes where `lazy_document_attribute` doc attributes are defined, use the `:update` method instead of `:index` during the after commit on update. It should avoid lose data. Note that if the document is not yet indexed, a second attempt using :index request will be done.