### PR TITLE
docs: add usage and API reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This gem is a [esse](https://github.com/marcosgz/esse) plugin for the ActiveRecord ORM. It provides a set of methods to simplify implementation of ActiveRecord models as datasource of esse indexes.
 
+## Documentation
+
+Full guides, usage examples, and API reference are published at **[gems.marcosz.com.br/esse-active_record](https://gems.marcosz.com.br/esse-active_record/)** — part of the [marcosgz Ruby gem catalogue](https://gems.marcosz.com.br).
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,58 @@
+# esse-active_record
+
+ActiveRecord integration for [Esse](../../esse/docs/README.md). Provides:
+
+- `collection Model` DSL for repositories, backed by `find_in_batches`.
+- Automatic `after_commit` callbacks to index, update, or delete documents.
+- Scoping and per-batch context fetching for efficient serialization.
+- Hook-based control to disable indexing globally, per-repository, or per-model.
+- Support for partial `:update` and lazy attribute denormalization.
+
+## Contents
+
+- [Usage guide](usage.md)
+- [API reference](api.md)
+
+## Quick start
+
+```ruby
+# Gemfile
+gem 'esse-active_record'
+```
+
+```ruby
+# app/indices/users_index.rb
+class UsersIndex < Esse::Index
+  plugin :active_record
+
+  repository :user do
+    collection ::User, batch_size: 500 do
+      scope :active, -> { where(active: true) }
+    end
+
+    document do |user, **|
+      { _id: user.id, name: user.name, email: user.email }
+    end
+  end
+end
+```
+
+```ruby
+# app/models/user.rb
+class User < ApplicationRecord
+  include Esse::ActiveRecord::Model
+  index_callback 'users_index:user'
+end
+```
+
+Every `User.create!`, `update!`, and `destroy` now syncs to Elasticsearch automatically.
+
+## Version
+
+- Version: **0.3.9**
+- Ruby: `>= 2.4.0`
+- Depends on: `esse >= 0.3.0`, `esse-hooks`, `activerecord >= 4.2`
+
+## License
+
+MIT.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,239 @@
+# API Reference
+
+## `Esse::Plugins::ActiveRecord`
+
+The plugin module. Registered via:
+
+```ruby
+class MyIndex < Esse::Index
+  plugin :active_record
+end
+```
+
+### Repository class methods
+
+#### `collection(model, **opts, &block)`
+
+Replaces the default `collection` DSL. Accepts a class inheriting from `::ActiveRecord::Base` or an `::ActiveRecord::Relation`.
+
+| Argument | Description |
+|----------|-------------|
+| `model` | AR class or relation |
+| `batch_size:` | Records per batch (default `1000`) |
+| `connect_with:` | Hash of `{role:, shard:}` for connection switching |
+| `&block` | Block evaluated in the collection class scope — use for `scope` / `batch_context` / `connected_to` |
+
+Returns an `Esse::ActiveRecord::Collection` subclass.
+
+#### `dataset(**params)`
+
+Returns the current filtered `ActiveRecord::Relation` (applies scopes).
+
+---
+
+## `Esse::ActiveRecord::Collection`
+
+Base class for collections built from ActiveRecord models. Subclasses are created automatically by the `collection` DSL.
+
+### Class-level DSL
+
+#### `scope(name, proc = nil, override: false, &block)`
+
+Define a named scope.
+
+```ruby
+collection ::User do
+  scope :active, -> { where(active: true) }
+  scope :role,   ->(role) { where(role: role) }
+end
+```
+
+#### `batch_context(name, proc = nil, override: false, &block)`
+
+Define a batch enrichment fetcher — invoked once per batch with `(records, **ctx)`.
+
+```ruby
+collection ::Order do
+  batch_context :customers do |orders, **|
+    Customer.where(id: orders.map(&:customer_id)).index_by(&:id)
+  end
+end
+```
+
+#### `connected_to(**kwargs)`
+
+Set database role/shard:
+
+```ruby
+collection ::User do
+  connected_to(role: :reading)
+end
+```
+
+### Instance methods
+
+| Method | Description |
+|--------|-------------|
+| `each { |rows, **ctx| }` | Iterate batches with applied scopes + batch contexts |
+| `each_batch_ids { |ids| }` | Iterate ID batches (skips eager loads) |
+| `count` / `size` | Total rows after scopes applied |
+| `dataset(**kwargs)` | Return filtered `ActiveRecord::Relation` |
+
+Constructor:
+
+```ruby
+CollectionClass.new(start: 1, finish: 10_000, batch_size: 500, **scope_args)
+```
+
+| Param | Description |
+|-------|-------------|
+| `start` | Primary key lower bound (inclusive) |
+| `finish` | Primary key upper bound (inclusive) |
+| `batch_size` | Overrides class default |
+| `**params` | Scope arguments and extra where-conditions |
+
+---
+
+## `Esse::ActiveRecord::Model`
+
+Mixin for ActiveRecord models. `include` it to register callbacks.
+
+### `index_callback(reference, on: [...], with: nil, **opts, &block)`
+
+Registers an `after_commit` callback that indexes the model into a repository.
+
+| Param | Description |
+|-------|-------------|
+| `reference` | `'index_name'` or `'index_name:repo_name'` (or class-constant form) |
+| `on:` | Which events — any subset of `[:create, :update, :destroy]`. Default: all three. |
+| `with:` | `:update` for partial updates, `nil` (default) for full reindex |
+| `if:` / `unless:` | Same semantics as AR `after_commit` |
+| `&block` | Optional — return the object to index (default: `self`) |
+
+Raises `ArgumentError` if the same repo already has a callback registered.
+
+### `update_lazy_attribute_callback(reference, attribute, on: [...], **opts, &block)`
+
+Registers a callback that calls `repo.update_documents_attribute(attribute, ids, opts)` on commit.
+
+```ruby
+update_lazy_attribute_callback('posts_index:post', 'comments_count') { post_id }
+```
+
+The block returns the ID (or array of IDs) of the document to update.
+
+### `without_indexing(*repos, &block)`
+
+Temporarily disables callbacks for this model class.
+
+```ruby
+User.without_indexing { User.create!(...) }
+User.without_indexing(UsersIndex) { User.create!(...) }
+```
+
+### `esse_callbacks`
+
+Returns a frozen hash of registered callbacks:
+
+```ruby
+User.esse_callbacks
+# => { 'users_index:user' => { create_indexing: [klass, opts, block], ... } }
+```
+
+---
+
+## `Esse::ActiveRecord::Hooks`
+
+Global state for enabling/disabling indexing callbacks. Uses [esse-hooks](../../esse-hooks/docs/README.md) under the hood.
+
+### `disable!` / `enable!`
+
+Toggle callbacks globally:
+
+```ruby
+Esse::ActiveRecord::Hooks.disable!
+# ... bulk work ...
+Esse::ActiveRecord::Hooks.enable!
+```
+
+### `without_indexing(*repos, &block)`
+
+Scoped disable, auto-restores state after the block.
+
+```ruby
+Esse::ActiveRecord::Hooks.without_indexing do
+  ...
+end
+
+Esse::ActiveRecord::Hooks.without_indexing(UsersIndex.repo(:user)) do
+  ...
+end
+```
+
+### `with_indexing(*repos, &block)`
+
+Opposite — forces enabling in a scope.
+
+### `enabled?(repo = nil)` / `disabled?(repo = nil)`
+
+Check global or per-repo status.
+
+### `resolve_index_repository(reference)`
+
+Resolve a string reference to a repository instance:
+
+```ruby
+Esse::ActiveRecord::Hooks.resolve_index_repository('users_index:user')
+# => UsersIndex.repo(:user)
+```
+
+Supported forms:
+
+- `'users'`
+- `'users_index'`
+- `'users_index:user'`
+- `'UsersIndex'`
+- `'UsersIndex::User'`
+- `'foo/v1/users_index/user'` (namespaced)
+
+### `register_model(model_class)` / `models`
+
+Used internally by `index_callback` to track model classes that have callbacks.
+
+---
+
+## Built-in callback classes
+
+Registered in `Esse::ActiveRecord::Callbacks`. All inherit from `Esse::ActiveRecord::Callback`.
+
+| Callback | Registered as | Behavior |
+|----------|---------------|----------|
+| `IndexingOnCreate` | `:create_indexing` | Calls `repo.index(doc)` on create |
+| `IndexingOnUpdate` | `:update_indexing` | Calls `repo.update(doc)` or `repo.index(doc)` (depending on `with:`). If routing changed, deletes the previous document at the old routing. |
+| `IndexingOnDestroy` | `:destroy_indexing` | Calls `repo.delete(doc)` on destroy. Silently handles `NotFoundError`. |
+| `UpdateLazyAttribute` | `:create_update_lazy_attribute`, `:update_update_lazy_attribute`, `:destroy_update_lazy_attribute` | Calls `repo.update_documents_attribute(attribute, ids, opts)` |
+
+### Custom callbacks
+
+Subclass `Esse::ActiveRecord::Callback`:
+
+```ruby
+class MyCallback < Esse::ActiveRecord::Callback
+  def call(model)
+    # ...
+  end
+end
+
+Esse::ActiveRecord::Callbacks.register_callback(:my_thing, :create, MyCallback)
+```
+
+Then reference it through your own DSL — use the built-in mechanism as a template.
+
+---
+
+## Deprecated methods
+
+| Deprecated | Use instead |
+|------------|-------------|
+| `index_callbacks` | `index_callback` |
+| `esse_index_repos` | `esse_callbacks` |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,272 @@
+# Usage Guide
+
+## Installation
+
+```ruby
+# Gemfile
+gem 'esse'
+gem 'esse-active_record'
+```
+
+```bash
+bundle install
+```
+
+Enable the plugin on any index:
+
+```ruby
+class UsersIndex < Esse::Index
+  plugin :active_record
+end
+```
+
+## The `collection` DSL
+
+Inside a repository, pass an ActiveRecord model (or relation) to `collection`:
+
+```ruby
+class UsersIndex < Esse::Index
+  plugin :active_record
+
+  repository :user do
+    collection ::User
+    document { |u, **| { _id: u.id, name: u.name } }
+  end
+end
+```
+
+Options:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `batch_size` | `1000` | Records per batch (`find_in_batches`) |
+| `connect_with` | — | `{ role: :reading }` / `{ shard: :primary }` to use connection switching |
+
+```ruby
+repository :user do
+  collection ::User, batch_size: 500, connect_with: { role: :reading }
+  document { |u, **| { _id: u.id, name: u.name } }
+end
+```
+
+## Scopes
+
+Define scopes to filter or shape the data at import time:
+
+```ruby
+repository :user do
+  collection ::User do
+    scope :active, -> { where(active: true) }
+    scope :role,   ->(role) { where(role: role) }
+  end
+
+  document { |u, **| { _id: u.id, name: u.name, role: u.role } }
+end
+
+# Apply at import:
+UsersIndex.import(context: { active: true, role: 'admin' })
+```
+
+Scopes are composable; arguments are passed positionally to the proc.
+
+## Batch context (avoid N+1)
+
+When serialization needs data from a related source, fetch it once per batch:
+
+```ruby
+repository :order do
+  collection ::Order do
+    batch_context :customers do |orders, **|
+      Customer.where(id: orders.map(&:customer_id)).index_by(&:id)
+    end
+  end
+
+  document do |order, customers: {}, **|
+    customer = customers[order.customer_id]
+    { _id: order.id, customer_name: customer&.name }
+  end
+end
+```
+
+The context is merged into each batch and forwarded to `document`.
+
+## Eager loading associations
+
+Just use `.includes`/`.eager_load` directly in the collection:
+
+```ruby
+repository :order do
+  collection ::Order.includes(:customer, :line_items)
+  document do |order, **|
+    { _id: order.id, customer: order.customer.name, line_count: order.line_items.size }
+  end
+end
+```
+
+## Automatic callbacks
+
+Include `Esse::ActiveRecord::Model` and declare `index_callback`:
+
+```ruby
+class User < ApplicationRecord
+  include Esse::ActiveRecord::Model
+  index_callback 'users_index:user'
+end
+```
+
+The reference format is `'index_name:repo_name'`. These all resolve to `UsersIndex.repo(:user)`:
+
+- `'users'`
+- `'users_index'`
+- `'users_index:user'`
+- `'UsersIndex'`
+- `'UsersIndex::User'`
+- `'foo/v1/users_index:user'` (namespaced)
+
+Options:
+
+```ruby
+index_callback 'users_index:user',
+  on:     %i[create update],   # default: [:create, :update, :destroy]
+  with:   :update,             # use ES update API (partial); falls back to index() on NotFound
+  if:     :active?,            # conditions work like ActiveRecord
+  unless: :deleted?
+```
+
+### Index an associated record instead
+
+Return the target object from the block:
+
+```ruby
+class City < ApplicationRecord
+  belongs_to :state
+  include Esse::ActiveRecord::Model
+
+  # Re-index the state when a city changes
+  index_callback('geos_index:state') { state }
+end
+```
+
+### Update a lazy attribute
+
+When a child record changes, update just one field on the parent document:
+
+```ruby
+class Comment < ApplicationRecord
+  belongs_to :post
+  include Esse::ActiveRecord::Model
+
+  update_lazy_attribute_callback('posts_index:post', 'comments_count') { post_id }
+end
+```
+
+The callback calls `repo.update_documents_attribute(:comments_count, [post_id], ...)`.
+
+## Disabling callbacks
+
+You will often want to turn callbacks off during bulk migrations, seeding, or tests.
+
+### Per-block
+
+```ruby
+Esse::ActiveRecord::Hooks.without_indexing do
+  10_000.times { User.create!(...) }
+end
+```
+
+### For specific repos
+
+```ruby
+Esse::ActiveRecord::Hooks.without_indexing(UsersIndex, AccountsIndex) do
+  migrate_users!
+end
+```
+
+### Per-model
+
+```ruby
+User.without_indexing { User.create!(...) }
+User.without_indexing(UsersIndex) { User.create!(...) }
+```
+
+### Globally
+
+```ruby
+Esse::ActiveRecord::Hooks.disable!
+# ... bulk operation ...
+Esse::ActiveRecord::Hooks.enable!
+```
+
+## Streaming by ID range
+
+Useful for parallel batch processing across workers:
+
+```ruby
+UsersIndex.import(context: { start: 1,     finish: 5000,  batch_size: 500 })
+UsersIndex.import(context: { start: 5001,  finish: 10000, batch_size: 500 })
+```
+
+`start` and `finish` are primary-key bounds (inclusive on both ends).
+
+## Async indexing
+
+The companion [esse-async_indexing](../../esse-async_indexing/docs/README.md) gem adds Sidekiq/Faktory-backed versions of all callbacks:
+
+```ruby
+require 'esse/async_indexing/active_record'
+
+class City < ApplicationRecord
+  include Esse::AsyncIndexing::ActiveRecord::Model
+
+  async_index_callback('geos_index:city', service_name: :sidekiq) { id }
+  async_update_lazy_attribute_callback(
+    'states_index:state', 'cities_count',
+    if: :state_id?,
+    service_name: :sidekiq
+  ) { state_id }
+end
+```
+
+## Patterns
+
+### Separate repositories on one index
+
+```ruby
+class UsersIndex < Esse::Index
+  plugin :active_record
+
+  repository :account do
+    collection ::Account
+    document { |a, **| { _id: a.id, name: a.name, type: 'account' } }
+  end
+
+  repository :admin do
+    collection ::User.where(admin: true)
+    document { |u, **| { _id: u.id, name: u.name, type: 'admin' } }
+  end
+end
+```
+
+### Multi-database with connection switching
+
+```ruby
+repository :user do
+  collection ::User, connect_with: { role: :reading }
+  # or inside the block:
+  collection ::User do
+    connected_to(role: :reading)
+  end
+  document { ... }
+end
+```
+
+### Disabling callbacks during bulk import
+
+```ruby
+Esse::ActiveRecord::Hooks.without_indexing do
+  seed_data!
+end
+
+# Now index them all
+UsersIndex.import
+```


### PR DESCRIPTION
## Summary

Adds `docs/` with three files:

- `README.md` — overview and entry point
- `usage.md` — how to wire the ActiveRecord collection + lifecycle callbacks into an Esse index
- `api.md` — reference for the public modules/methods exposed by this gem

## Test plan

- [ ] Skim `docs/README.md` as a navigation entry point
- [ ] Verify `usage.md` examples match the current API
- [ ] Verify `api.md` method signatures are correct